### PR TITLE
Implement weapon and item effect logic

### DIFF
--- a/src/renderer/src/game/entities/living/Player.ts
+++ b/src/renderer/src/game/entities/living/Player.ts
@@ -35,6 +35,10 @@ export class Player extends LivingEntity {
   levelManager: LevelManager;
   uiManager: UIManager;
 
+  attackSpeedBonus = 0;
+  damageBonus = 0;
+  projectileScaleBonus = 0;
+
   constructor(scene: Game, x: number, y: number) {
     super(scene, x, y, 'player', 'player');
     this.speed = GAME_CONFIG.PLAYER.DEFAULT_SPEED;

--- a/src/renderer/src/game/entities/projectiles/NeedleProjectile.ts
+++ b/src/renderer/src/game/entities/projectiles/NeedleProjectile.ts
@@ -1,0 +1,27 @@
+import { Scene } from 'phaser';
+import { LivingEntity } from '../living/LivingEntity';
+import { Projectile } from './Projectile';
+
+export class NeedleProjectile extends Projectile {
+  constructor(
+    scene: Scene,
+    x: number,
+    y: number,
+    vx: number,
+    vy: number,
+    damage: number,
+    lifetime: number = 2
+  ) {
+    super(scene, x, y, vx, vy, damage, 5, lifetime, Math.sqrt(vx * vx + vy * vy), 'projectile');
+  }
+
+  onHit(target: LivingEntity): void {
+    const body = target.sprite.body as Phaser.Physics.Arcade.Body;
+    const originalVelocity = body.velocity.clone();
+    body.setVelocity(0, 0);
+    this.scene.time.delayedCall(400, () => {
+      body.setVelocity(originalVelocity.x, originalVelocity.y);
+    });
+  }
+}
+

--- a/src/renderer/src/game/entities/projectiles/index.ts
+++ b/src/renderer/src/game/entities/projectiles/index.ts
@@ -1,3 +1,4 @@
 export * from './KnifeProjectile';
 export * from './Projectile';
 export * from './TestProjectile';
+export * from './NeedleProjectile';

--- a/src/renderer/src/game/items/BlessedNecklace.ts
+++ b/src/renderer/src/game/items/BlessedNecklace.ts
@@ -1,0 +1,23 @@
+import { Player } from '../entities/living';
+import { Item } from './Item';
+
+export class BlessedNecklace extends Item {
+  private speedBonuses = [0, 0.05, 0.075, 0.1, 0.15];
+
+  constructor() {
+    super('무언가의 축복이 담긴 목걸이', '공격 속도가 증가한다', 'blessed_necklace_icon');
+  }
+
+  applyEffect(player: Player): void {
+    this.recalc(player);
+  }
+
+  protected onLevelUp(player: Player): void {
+    this.recalc(player);
+  }
+
+  private recalc(player: Player) {
+    player.attackSpeedBonus = this.speedBonuses[this.level - 1];
+  }
+}
+

--- a/src/renderer/src/game/items/BrokenGlasses.ts
+++ b/src/renderer/src/game/items/BrokenGlasses.ts
@@ -1,0 +1,23 @@
+import { Player } from '../entities/living';
+import { Item } from './Item';
+
+export class BrokenGlasses extends Item {
+  private sizeBonuses = [0.05, 0.1, 0.125, 0.15, 0.2];
+
+  constructor() {
+    super('부러진 안경', '투사체 크기가 증가한다', 'broken_glasses_icon');
+  }
+
+  applyEffect(player: Player): void {
+    this.recalc(player);
+  }
+
+  protected onLevelUp(player: Player): void {
+    this.recalc(player);
+  }
+
+  private recalc(player: Player) {
+    player.projectileScaleBonus = this.sizeBonuses[this.level - 1];
+  }
+}
+

--- a/src/renderer/src/game/items/ChocolateChip.ts
+++ b/src/renderer/src/game/items/ChocolateChip.ts
@@ -2,7 +2,8 @@ import { Player } from '../entities/living';
 import { Item } from './Item';
 
 export class ChocolateChip extends Item {
-  private cooldowns = [60, 55, 50, 45, 40];
+  private cooldowns = [16, 14, 12, 10, 10];
+  private healAmounts = [10, 14, 18, 21, 20];
   private timer = 0;
 
   constructor() {
@@ -18,8 +19,12 @@ export class ChocolateChip extends Item {
     this.timer += delta / 1000;
     if (this.timer >= this.cooldowns[this.level - 1]) {
       this.timer = 0;
-      // TODO: 실제 회복 오브젝트 스폰 로직 추가
-      console.log('Spawn chocolate heal item');
+      const healTicks = this.level >= 5 ? 2 : 1;
+      const heal = this.healAmounts[this.level - 1];
+
+      for (let i = 0; i < healTicks; i++) {
+        _player.healthManager.heal(heal);
+      }
     }
   }
 }

--- a/src/renderer/src/game/items/CrealCloack.ts
+++ b/src/renderer/src/game/items/CrealCloack.ts
@@ -3,8 +3,8 @@ import { Game } from '../scenes/Game';
 import { Item } from './Item';
 
 export class CreamCloak extends Item {
-  private slowRates = [0.05, 0.07, 0.1, 0.15, 0.2];
-  private radius = 120;
+  private slowRates = [0.25, 0.3, 0.35, 0.4, 0.5];
+  private radius = 160;
 
   constructor() {
     super('슈크림 망토', '주변 적의 속도를 감소시킨다', 'cream_cloak_icon');

--- a/src/renderer/src/game/items/MartialManual.ts
+++ b/src/renderer/src/game/items/MartialManual.ts
@@ -1,0 +1,23 @@
+import { Player } from '../entities/living';
+import { Item } from './Item';
+
+export class MartialManual extends Item {
+  private damageBonuses = [0.05, 0.075, 0.1, 0.125, 0.15];
+
+  constructor() {
+    super('무공비급서', '공격력이 증가한다', 'martial_manual_icon');
+  }
+
+  applyEffect(player: Player): void {
+    this.recalc(player);
+  }
+
+  protected onLevelUp(player: Player): void {
+    this.recalc(player);
+  }
+
+  private recalc(player: Player) {
+    player.damageBonus = this.damageBonuses[this.level - 1];
+  }
+}
+

--- a/src/renderer/src/game/items/index.ts
+++ b/src/renderer/src/game/items/index.ts
@@ -3,3 +3,6 @@ export * from './Item';
 export * from './ChocolateChip';
 export * from './CrealCloack';
 export * from './JellyCrown';
+export * from './BrokenGlasses';
+export * from './BlessedNecklace';
+export * from './MartialManual';

--- a/src/renderer/src/game/managers/WeaponManager.ts
+++ b/src/renderer/src/game/managers/WeaponManager.ts
@@ -25,7 +25,11 @@ export class WeaponManager {
 
   attack(dt: number) {
     for (const weapon of this.weapons.values()) {
-      weapon.currentCooldown -= dt;
+      const attackSpeedMultiplier = 1 + (this.player.attackSpeedBonus ?? 0);
+
+      weapon.currentCooldown -= dt * attackSpeedMultiplier;
+
+      weapon.update?.(dt);
 
       if (weapon.currentCooldown <= 0) {
         weapon.currentCooldown += weapon.cooldown;

--- a/src/renderer/src/game/weapons/JellyBombardment.ts
+++ b/src/renderer/src/game/weapons/JellyBombardment.ts
@@ -1,0 +1,66 @@
+import { Scene } from 'phaser';
+import { Player } from '../entities/living';
+import { Weapon } from './Weapon';
+import { Game } from '../scenes/Game';
+
+export class JellyBombardment extends Weapon {
+  private damages = [100, 100, 300, 300, 300];
+  private cooldowns = [20, 15, 15, 15, 15];
+  private radii = [60, 60, 60, 90, 90];
+
+  constructor(scene: Scene, player: Player) {
+    super(scene, '젤리 폭격', '적 위치에 포격', player, 0, 0, 20, 100);
+  }
+
+  attack(): void {
+    if (!(this.scene instanceof Game)) return;
+
+    const damageMultiplier = 1 + (this.player.damageBonus ?? 0);
+    const damage = this.damages[this.level - 1] * damageMultiplier;
+    const radius = this.radii[this.level - 1];
+
+    for (let i = 0; i < 3; i++) {
+      this.scene.time.delayedCall(i * 200, () => {
+        const target = this.pickTarget();
+        if (!target) return;
+        this.dealExplosion(target.x, target.y, radius, damage);
+
+        if (this.level >= 5) {
+          this.createFireZone(target.x, target.y, radius);
+        }
+      });
+    }
+  }
+
+  protected onLevelUp(_player: Player): void {
+    this.cooldown = this.cooldowns[this.level - 1];
+  }
+
+  private pickTarget() {
+    const enemies = this.scene.enemyManager.enemiesGroup.getChildren();
+    if (enemies.length === 0) return null;
+    return enemies[Math.floor(Math.random() * enemies.length)] as Phaser.GameObjects.Sprite;
+  }
+
+  private dealExplosion(x: number, y: number, radius: number, damage: number) {
+    const r2 = radius * radius;
+    this.scene.enemyManager.enemiesGroup.getChildren().forEach((sprite) => {
+      const enemy = sprite as Phaser.GameObjects.Sprite & { entity: any };
+      const dx = enemy.x - x;
+      const dy = enemy.y - y;
+      if (dx * dx + dy * dy <= r2) {
+        enemy.entity.healthManager.takeDamage(damage);
+      }
+    });
+  }
+
+  private createFireZone(x: number, y: number, radius: number) {
+    const damagePerTick = 45 * (1 + (this.player.damageBonus ?? 0));
+    for (let i = 1; i <= 5; i++) {
+      this.scene.time.delayedCall(i * 1000, () => {
+        this.dealExplosion(x, y, radius, damagePerTick);
+      });
+    }
+  }
+}
+

--- a/src/renderer/src/game/weapons/JellySpirit.ts
+++ b/src/renderer/src/game/weapons/JellySpirit.ts
@@ -1,0 +1,58 @@
+import { Scene } from 'phaser';
+import { Player } from '../entities/living';
+import { Weapon } from './Weapon';
+import { Game } from '../scenes/Game';
+
+export class JellySpirit extends Weapon {
+  private damages = [90, 90, 90, 140, 140];
+  private cooldowns = [10, 7, 7, 7, 7];
+  private explosionRadius = [80, 80, 110, 110, 110];
+
+  constructor(scene: Scene, player: Player) {
+    super(scene, '곰젤리의 원혼', '주기적으로 폭탄을 소환한다', player, 0, 0, 10, 90);
+  }
+
+  attack(): void {
+    if (!(this.scene instanceof Game)) return;
+
+    const damageMultiplier = 1 + (this.player.damageBonus ?? 0);
+    const damage = this.damages[this.level - 1] * damageMultiplier;
+    const radius = this.explosionRadius[this.level - 1];
+    const bombCount = this.level >= 5 ? 2 : 1;
+
+    for (let i = 0; i < bombCount; i++) {
+      this.spawnBomb(damage, radius);
+    }
+  }
+
+  protected onLevelUp(_player: Player): void {
+    this.cooldown = this.cooldowns[this.level - 1];
+  }
+
+  private spawnBomb(damage: number, radius: number) {
+    const enemies = this.scene.enemyManager.enemiesGroup.getChildren();
+    let targetX = this.player.x;
+    let targetY = this.player.y;
+
+    if (enemies.length > 0) {
+      const target = enemies[Math.floor(Math.random() * enemies.length)] as Phaser.GameObjects.Sprite;
+      targetX = target.x;
+      targetY = target.y;
+    }
+
+    this.scene.time.delayedCall(500, () => {
+      const r2 = radius * radius;
+      this.scene.enemyManager.enemiesGroup
+        .getChildren()
+        .forEach((sprite) => {
+          const enemy = sprite as Phaser.GameObjects.Sprite & { entity: any };
+          const dx = enemy.x - targetX;
+          const dy = enemy.y - targetY;
+          if (dx * dx + dy * dy <= r2) {
+            enemy.entity.healthManager.takeDamage(damage);
+          }
+        });
+    });
+  }
+}
+

--- a/src/renderer/src/game/weapons/JellyStaff.ts
+++ b/src/renderer/src/game/weapons/JellyStaff.ts
@@ -1,0 +1,68 @@
+import { Scene } from 'phaser';
+import { Player } from '../entities/living';
+import { Weapon } from './Weapon';
+import { Game } from '../scenes/Game';
+
+interface OrbitingHead {
+  sprite: Phaser.GameObjects.Arc;
+  angle: number;
+}
+
+export class JellyStaff extends Weapon {
+  private heads: OrbitingHead[] = [];
+  private damageLevels = [50, 75, 75, 75, 100];
+  private rotationPeriods = [3, 3, 2, 2, 1.5];
+  private radius = 70;
+
+  constructor(scene: Scene, player: Player) {
+    super(scene, '곰젤리의 지팡이', '곰젤리 머리가 주위를 돈다', player, 0, 0, 0.2, 50);
+    this.setupHeads();
+  }
+
+  attack(): void {
+    // damage is handled in update()
+  }
+
+  update(dt: number): void {
+    if (!(this.scene instanceof Game)) return;
+
+    const headCount = this.level >= 4 ? 4 : 3;
+    if (this.heads.length !== headCount) {
+      this.resetHeads(headCount);
+    }
+
+    const damageMultiplier = 1 + (this.player.damageBonus ?? 0);
+    const damage = this.damageLevels[this.level - 1] * damageMultiplier;
+    const rotationSpeed = (Math.PI * 2) / this.rotationPeriods[this.level - 1];
+
+    this.heads.forEach((head, index) => {
+      head.angle += rotationSpeed * dt;
+      const angle = head.angle + (index * Math.PI * 2) / this.heads.length;
+      head.sprite.x = this.player.x + Math.cos(angle) * this.radius;
+      head.sprite.y = this.player.y + Math.sin(angle) * this.radius;
+
+      this.scene.enemyManager.enemiesGroup.getChildren().forEach((sprite) => {
+        const enemy = sprite as Phaser.GameObjects.Sprite & { entity: any };
+        const dx = enemy.x - head.sprite.x;
+        const dy = enemy.y - head.sprite.y;
+        if (dx * dx + dy * dy <= 20 * 20) {
+          enemy.entity.healthManager.takeDamage(damage);
+        }
+      });
+    });
+  }
+
+  private setupHeads() {
+    this.resetHeads(3);
+  }
+
+  private resetHeads(count: number) {
+    this.heads.forEach((h) => h.sprite.destroy());
+    this.heads = [];
+    for (let i = 0; i < count; i++) {
+      const sprite = this.scene.add.circle(this.player.x, this.player.y, 10, 0x00ffcc).setDepth(1);
+      this.heads.push({ sprite, angle: 0 });
+    }
+  }
+}
+

--- a/src/renderer/src/game/weapons/Knife.ts
+++ b/src/renderer/src/game/weapons/Knife.ts
@@ -25,16 +25,18 @@ export class Knife extends Weapon {
     const vx = (dx / len) * this.speed;
     const vy = (dy / len) * this.speed;
 
+    const damageMultiplier = 1 + (this.player.damageBonus ?? 0);
     const proj = new KnifeProjectile(
       this.scene,
       this.player.x,
       this.player.y,
       vx,
       vy,
-      this.damage,
+      this.damage * damageMultiplier,
       this.speed,
       this.lifetime
     );
+    proj.sprite.setScale(1 + (this.player.projectileScaleBonus ?? 0));
     if (this.scene instanceof Game)
       this.scene.projectileManager.add(proj.sprite);
   }

--- a/src/renderer/src/game/weapons/MorningStar.ts
+++ b/src/renderer/src/game/weapons/MorningStar.ts
@@ -1,0 +1,67 @@
+import { Scene } from 'phaser';
+import { Player } from '../entities/living';
+import { Weapon } from './Weapon';
+import { Game } from '../scenes/Game';
+
+export class MorningStar extends Weapon {
+  private damages = [30, 45, 60, 75, 90];
+  private slamRadius = 48;
+  private shockwaveRadius = 120;
+  private shockwaveDamage = 40;
+
+  constructor(scene: Scene, player: Player) {
+    super(scene, '모닝스타', '근접 내려찍기 공격', player, 0, 0, 1, 30);
+  }
+
+  attack(): void {
+    if (!(this.scene instanceof Game)) return;
+
+    const damageMultiplier = 1 + (this.player.damageBonus ?? 0);
+    const currentDamage = this.damages[this.level - 1] * damageMultiplier;
+
+    const pointer = this.scene.input.activePointer;
+    const dx = pointer.worldX - this.player.x;
+    const dy = pointer.worldY - this.player.y;
+    const len = Math.sqrt(dx * dx + dy * dy) || 1;
+    const targetX = this.player.x + (dx / len) * 60;
+    const targetY = this.player.y + (dy / len) * 60;
+
+    this.damageCircle(targetX, targetY, this.slamRadius, currentDamage);
+
+    if (this.level >= 5) {
+      this.damageCircle(
+        targetX,
+        targetY,
+        this.shockwaveRadius,
+        this.shockwaveDamage * damageMultiplier
+      );
+    }
+  }
+
+  protected onLevelUp(_player: Player): void {
+    if (this.level >= 2) {
+      this.cooldown = 1 / 1.2;
+    }
+  }
+
+  private damageCircle(
+    x: number,
+    y: number,
+    radius: number,
+    damage: number
+  ) {
+    const enemies = this.scene.enemyManager.enemiesGroup
+      .getChildren()
+      .map((c) => c as Phaser.GameObjects.Sprite & { entity: any });
+
+    const r2 = radius * radius;
+    for (const enemy of enemies) {
+      const dx = enemy.x - x;
+      const dy = enemy.y - y;
+      if (dx * dx + dy * dy <= r2) {
+        enemy.entity.healthManager.takeDamage(damage);
+      }
+    }
+  }
+}
+

--- a/src/renderer/src/game/weapons/Needle.ts
+++ b/src/renderer/src/game/weapons/Needle.ts
@@ -1,0 +1,50 @@
+import { Scene } from 'phaser';
+import { Player } from '../entities/living';
+import { Weapon } from './Weapon';
+import { NeedleProjectile } from '../entities/projectiles';
+import { Game } from '../scenes/Game';
+
+export class Needle extends Weapon {
+  private damages = [35, 40, 50, 50, 50];
+  private cooldowns = [0.5, 0.666, 1, 1.2, 1.2];
+
+  constructor(scene: Scene, player: Player) {
+    super(scene, '바늘', '짧은 사거리 투척', player, 0, 0, 0.5, 35, 300, 2);
+  }
+
+  attack(): void {
+    if (!(this.scene instanceof Game)) return;
+
+    const pointer = this.scene.input.activePointer;
+    const dx = pointer.worldX - this.player.x;
+    const dy = pointer.worldY - this.player.y;
+    const len = Math.sqrt(dx * dx + dy * dy) || 1;
+
+    const speed = 300;
+    const vx = (dx / len) * speed;
+    const vy = (dy / len) * speed;
+
+    const damageMultiplier = 1 + (this.player.damageBonus ?? 0);
+    const damage = this.damages[this.level - 1] * damageMultiplier;
+    const projectileCount = this.level >= 5 ? 2 : 1;
+
+    for (let i = 0; i < projectileCount; i++) {
+      const proj = new NeedleProjectile(
+        this.scene,
+        this.player.x,
+        this.player.y,
+        vx,
+        vy,
+        damage,
+        1.5
+      );
+      proj.sprite.setScale(1 + (this.player.projectileScaleBonus ?? 0));
+      this.scene.projectileManager.add(proj.sprite);
+    }
+  }
+
+  protected onLevelUp(_player: Player): void {
+    this.cooldown = this.cooldowns[this.level - 1];
+  }
+}
+

--- a/src/renderer/src/game/weapons/Weapon.ts
+++ b/src/renderer/src/game/weapons/Weapon.ts
@@ -52,6 +52,8 @@ export abstract class Weapon {
 
   abstract attack(): void;
 
+  update?(_dt: number): void;
+
   levelUp(player: Player) {
     if (!this.isMaxLevel) {
       this.level++;

--- a/src/renderer/src/game/weapons/index.ts
+++ b/src/renderer/src/game/weapons/index.ts
@@ -3,3 +3,8 @@ export * from './Weapon';
 export * from './Knife';
 export * from './Test';
 export * from './Test2';
+export * from './MorningStar';
+export * from './JellySpirit';
+export * from './JellyStaff';
+export * from './JellyBombardment';
+export * from './Needle';


### PR DESCRIPTION
## Summary
- implement detailed behaviors for Morningstar, Jelly Spirit bombs, Jelly Staff orbitals, Jelly Bombardment strikes, and Needle projectiles
- add new passive items that buff attack speed, damage, projectile size, and adjust existing healing/slow effects to match design
- extend weapon handling to respect global attack speed bonuses and provide optional per-frame updates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692695d128688332a3f400b10121808f)