### PR TITLE
Improve mobile joystick stability and UI friendliness

### DIFF
--- a/src/renderer/src/game/entities/living/Player.ts
+++ b/src/renderer/src/game/entities/living/Player.ts
@@ -275,13 +275,16 @@ export class Player extends LivingEntity {
   }
 
   private handleMovement() {
-    let vx = 0,
-      vy = 0;
+    const input = (this.scene as Game).inputManager;
+    const move = input.getMoveVector(this.keys, this.cursors);
+    let vx = move.x * this.speed;
+    let vy = move.y * this.speed;
 
-    if (this.keys.w.isDown || this.cursors.up.isDown) vy = -this.speed;
-    if (this.keys.s.isDown || this.cursors.down.isDown) vy = this.speed;
-    if (this.keys.a.isDown || this.cursors.left.isDown) vx = -this.speed;
-    if (this.keys.d.isDown || this.cursors.right.isDown) vx = this.speed;
+    const length = Math.hypot(vx, vy);
+    if (length > this.speed) {
+      vx = (vx / length) * this.speed;
+      vy = (vy / length) * this.speed;
+    }
 
     if (this.sprite.body instanceof Phaser.Physics.Arcade.Body) {
       this.sprite.body.setVelocity(vx, vy);

--- a/src/renderer/src/game/input/InputManager.ts
+++ b/src/renderer/src/game/input/InputManager.ts
@@ -1,0 +1,174 @@
+import Phaser from 'phaser';
+import {
+  JoystickUIBlocker,
+  VirtualJoystick,
+  VirtualJoystickConfig
+} from './VirtualJoystick';
+
+type Vector = { x: number; y: number };
+
+const JOYSTICK_MODE: 'fixed' | 'floating' = 'fixed';
+const MOVE_SMOOTHING_ALPHA = 0.18;
+const AIM_SMOOTHING_ALPHA = 0.25;
+
+export class InputManager {
+  scene: Phaser.Scene;
+  isTouchDevice: boolean;
+
+  private leftJoystick?: VirtualJoystick;
+  private rightJoystick?: VirtualJoystick;
+  private lastAim: Vector = { x: 1, y: 0 };
+  private enabled = true;
+
+  constructor(scene: Phaser.Scene) {
+    this.scene = scene;
+    this.isTouchDevice =
+      !scene.sys.game.device.os.desktop ||
+      scene.sys.game.device.input.touch;
+
+    if (this.isTouchDevice) {
+      this.ensurePointers();
+
+      const uiBlocker: JoystickUIBlocker = (currentlyOver, joystickObjects) => {
+        return currentlyOver.some(
+          (obj) =>
+            (obj as any).input?.enabled === true && !joystickObjects.has(obj)
+        );
+      };
+
+      const createConfig = (
+        side: 'left' | 'right',
+        smoothingAlpha: number
+      ): VirtualJoystickConfig => ({
+        side,
+        mode: JOYSTICK_MODE,
+        smoothingAlpha,
+        deadzone: 0.15,
+        marginX: 32,
+        marginY: 44,
+        uiBlocker
+      });
+
+      this.leftJoystick = new VirtualJoystick(
+        scene,
+        createConfig('left', MOVE_SMOOTHING_ALPHA)
+      );
+      this.rightJoystick = new VirtualJoystick(
+        scene,
+        createConfig('right', AIM_SMOOTHING_ALPHA)
+      );
+    }
+  }
+
+  update(_time?: number, _delta?: number): void {
+    if (!this.isTouchDevice || !this.enabled) {
+      return;
+    }
+
+    const aim = this.rightJoystick?.getValue() ?? { x: 0, y: 0 };
+    if (aim.x !== 0 || aim.y !== 0) {
+      const len = Math.hypot(aim.x, aim.y) || 1;
+      this.lastAim = { x: aim.x / len, y: aim.y / len };
+    }
+  }
+
+  setEnabled(enabled: boolean) {
+    this.enabled = enabled;
+    if (!this.isTouchDevice) return;
+
+    this.leftJoystick?.setEnabled(enabled);
+    this.rightJoystick?.setEnabled(enabled);
+  }
+
+  setVisible(visible: boolean) {
+    if (!this.isTouchDevice) return;
+    this.leftJoystick?.setVisible(visible);
+    this.rightJoystick?.setVisible(visible);
+  }
+
+  reset(options?: { keepLastAim?: boolean }) {
+    if (!this.isTouchDevice) return;
+    this.leftJoystick?.reset();
+    this.rightJoystick?.reset();
+
+    if (!options?.keepLastAim) {
+      this.lastAim = { x: 1, y: 0 };
+    }
+  }
+
+  destroy() {
+    this.leftJoystick?.destroy();
+    this.rightJoystick?.destroy();
+  }
+
+  getMoveVector(
+    keys: Record<string, Phaser.Input.Keyboard.Key>,
+    cursors: Phaser.Types.Input.Keyboard.CursorKeys
+  ): Vector {
+    if (!this.isTouchDevice && keys && cursors) {
+      let x = 0;
+      let y = 0;
+
+      if (keys.w.isDown || cursors.up.isDown) y -= 1;
+      if (keys.s.isDown || cursors.down.isDown) y += 1;
+      if (keys.a.isDown || cursors.left.isDown) x -= 1;
+      if (keys.d.isDown || cursors.right.isDown) x += 1;
+
+      const len = Math.hypot(x, y) || 1;
+      return len > 1 ? { x: x / len, y: y / len } : { x, y };
+    }
+
+    if (this.isTouchDevice && this.enabled && this.leftJoystick) {
+      const value = this.leftJoystick.getValue();
+      const len = Math.hypot(value.x, value.y) || 1;
+      return len > 1 ? { x: value.x / len, y: value.y / len } : value;
+    }
+
+    return { x: 0, y: 0 };
+  }
+
+  getAimVector(playerX: number, playerY: number): Vector {
+    if (!this.isTouchDevice) {
+      const pointer = this.scene.input.activePointer;
+      const dx = pointer.worldX - playerX;
+      const dy = pointer.worldY - playerY;
+      const len = Math.hypot(dx, dy) || 1;
+      return { x: dx / len, y: dy / len };
+    }
+
+    if (this.enabled && this.rightJoystick) {
+      const value = this.rightJoystick.getValue();
+      const len = Math.hypot(value.x, value.y);
+
+      if (len > 0.12) {
+        this.lastAim = { x: value.x / len, y: value.y / len };
+      }
+    }
+
+    return { ...this.lastAim };
+  }
+
+  getAimWorldPoint(playerX: number, playerY: number, distance: number = 140) {
+    if (!this.isTouchDevice) {
+      const pointer = this.scene.input.activePointer;
+      return { x: pointer.worldX, y: pointer.worldY };
+    }
+
+    const aim = this.getAimVector(playerX, playerY);
+    return {
+      x: playerX + aim.x * distance,
+      y: playerY + aim.y * distance
+    };
+  }
+
+  private ensurePointers() {
+    const input = this.scene.input;
+    const manager = input.manager;
+    const required = 3;
+    const current = manager.pointers.length;
+    if (current < required) {
+      const toAdd = required - current;
+      input.addPointer(toAdd);
+    }
+  }
+}

--- a/src/renderer/src/game/input/VirtualJoystick.ts
+++ b/src/renderer/src/game/input/VirtualJoystick.ts
@@ -1,0 +1,289 @@
+import Phaser from 'phaser';
+
+type JoystickSide = 'left' | 'right';
+type JoystickMode = 'fixed' | 'floating';
+
+type Vector = { x: number; y: number };
+
+export type JoystickUIBlocker = (
+  currentlyOver: Phaser.GameObjects.GameObject[],
+  joystickObjects: Set<Phaser.GameObjects.GameObject>
+) => boolean;
+
+export type VirtualJoystickConfig = {
+  side: JoystickSide;
+  mode: JoystickMode;
+  depth?: number;
+  deadzone?: number;
+  smoothingAlpha?: number;
+  marginX?: number;
+  marginY?: number;
+  minRadius?: number;
+  maxRadius?: number;
+  uiBlocker?: JoystickUIBlocker;
+};
+
+export class VirtualJoystick {
+  private scene: Phaser.Scene;
+  private side: JoystickSide;
+  private mode: JoystickMode;
+  private depth: number;
+  private deadzone: number;
+  private smoothingAlpha: number;
+  private marginX: number;
+  private marginY: number;
+  private minRadius: number;
+  private maxRadius: number;
+  private uiBlocker?: JoystickUIBlocker;
+
+  private base: Phaser.GameObjects.Graphics;
+  private thumb: Phaser.GameObjects.Graphics;
+  private joystickObjects: Set<Phaser.GameObjects.GameObject>;
+
+  private pointerId: number | null = null;
+  private radius: number = 70;
+  private thumbRadius: number = 40;
+  private defaultBase: Vector = { x: 0, y: 0 };
+  private smoothedValue: Vector = { x: 0, y: 0 };
+  private rawValue: Vector = { x: 0, y: 0 };
+
+  private enabled = true;
+  private visible = true;
+
+  private resizeHandler = (gameSize: Phaser.Structs.Size) =>
+    this.onResize(gameSize.width, gameSize.height);
+
+  constructor(scene: Phaser.Scene, config: VirtualJoystickConfig) {
+    this.scene = scene;
+    this.side = config.side;
+    this.mode = config.mode;
+    this.depth = config.depth ?? 1000;
+    this.deadzone = config.deadzone ?? 0.15;
+    this.smoothingAlpha = config.smoothingAlpha ?? 0.2;
+    this.marginX = config.marginX ?? 32;
+    this.marginY = config.marginY ?? 40;
+    this.minRadius = config.minRadius ?? 60;
+    this.maxRadius = config.maxRadius ?? 110;
+    this.uiBlocker = config.uiBlocker;
+
+    this.base = this.scene.add.graphics();
+    this.thumb = this.scene.add.graphics();
+    this.joystickObjects = new Set([this.base, this.thumb]);
+
+    this.base.setScrollFactor(0).setDepth(this.depth);
+    this.thumb.setScrollFactor(0).setDepth(this.depth + 1);
+
+    this.drawGraphics();
+    this.positionDefault(this.scene.scale.width, this.scene.scale.height);
+
+    this.scene.input.on('pointerdown', this.handlePointerDown);
+    this.scene.input.on('pointermove', this.handlePointerMove);
+    this.scene.input.on('pointerup', this.handlePointerUp);
+    this.scene.input.on('pointerupoutside', this.handlePointerUp);
+    this.scene.scale.on('resize', this.resizeHandler);
+  }
+
+  getValue(): Vector {
+    if (!this.enabled) return { x: 0, y: 0 };
+    return { ...this.smoothedValue };
+  }
+
+  setEnabled(enabled: boolean) {
+    this.enabled = enabled;
+    if (!enabled) {
+      this.releasePointer();
+      this.resetValue();
+    }
+  }
+
+  setVisible(visible: boolean) {
+    this.visible = visible;
+    this.base.setVisible(visible);
+    this.thumb.setVisible(visible);
+  }
+
+  reset() {
+    this.releasePointer();
+    this.resetValue();
+    this.recenterThumb();
+  }
+
+  destroy() {
+    this.scene.input.off('pointerdown', this.handlePointerDown);
+    this.scene.input.off('pointermove', this.handlePointerMove);
+    this.scene.input.off('pointerup', this.handlePointerUp);
+    this.scene.input.off('pointerupoutside', this.handlePointerUp);
+    this.scene.scale.off('resize', this.resizeHandler);
+
+    this.base.destroy();
+    this.thumb.destroy();
+  }
+
+  private handlePointerDown = (
+    pointer: Phaser.Input.Pointer,
+    currentlyOver: Phaser.GameObjects.GameObject[]
+  ) => {
+    if (!this.enabled) return;
+    if (this.pointerId !== null) return;
+    if (this.uiBlocker?.(currentlyOver, this.joystickObjects)) return;
+    if (!this.isWithinZone(pointer)) return;
+
+    this.capture(pointer);
+    this.updateValue(pointer);
+  };
+
+  private handlePointerMove = (pointer: Phaser.Input.Pointer) => {
+    if (pointer.id !== this.pointerId) return;
+    this.updateValue(pointer);
+  };
+
+  private handlePointerUp = (pointer: Phaser.Input.Pointer) => {
+    if (pointer.id !== this.pointerId) return;
+    this.releasePointer();
+    this.resetValue();
+    this.recenterThumb();
+  };
+
+  private capture(pointer: Phaser.Input.Pointer) {
+    this.pointerId = pointer.id;
+
+    if (this.mode === 'floating') {
+      const clamped = this.clampToHalf(pointer.x, pointer.y);
+      this.base.setPosition(clamped.x, clamped.y);
+      this.thumb.setPosition(clamped.x, clamped.y);
+    }
+  }
+
+  private releasePointer() {
+    this.pointerId = null;
+    if (this.mode === 'floating') {
+      this.base.setPosition(this.defaultBase.x, this.defaultBase.y);
+    }
+  }
+
+  private updateValue(pointer: Phaser.Input.Pointer) {
+    const dx = pointer.x - this.base.x;
+    const dy = pointer.y - this.base.y;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+    const clampedDistance = Math.min(distance, this.radius);
+
+    const angle = Math.atan2(dy, dx);
+    const offsetX = Math.cos(angle) * clampedDistance;
+    const offsetY = Math.sin(angle) * clampedDistance;
+
+    this.thumb.setPosition(this.base.x + offsetX, this.base.y + offsetY);
+
+    const magnitude = clampedDistance / this.radius;
+    let x = 0;
+    let y = 0;
+    if (magnitude >= this.deadzone) {
+      const norm = Math.max(distance, 0.0001);
+      x = (dx / norm) * magnitude;
+      y = (dy / norm) * magnitude;
+    }
+
+    this.rawValue = { x, y };
+    this.applySmoothing();
+  }
+
+  private applySmoothing() {
+    this.smoothedValue = {
+      x:
+        this.smoothedValue.x * (1 - this.smoothingAlpha) +
+        this.rawValue.x * this.smoothingAlpha,
+      y:
+        this.smoothedValue.y * (1 - this.smoothingAlpha) +
+        this.rawValue.y * this.smoothingAlpha
+    };
+  }
+
+  private resetValue() {
+    this.rawValue = { x: 0, y: 0 };
+    this.smoothedValue = { x: 0, y: 0 };
+  }
+
+  private recenterThumb() {
+    this.thumb.setPosition(this.base.x, this.base.y);
+  }
+
+  private positionDefault(width: number, height: number) {
+    this.radius = Phaser.Math.Clamp(
+      Math.min(width, height) * 0.12,
+      this.minRadius,
+      this.maxRadius
+    );
+    this.thumbRadius = Math.floor(this.radius * 0.55);
+    this.drawGraphics();
+
+    const x =
+      this.side === 'left'
+        ? this.radius + this.marginX
+        : width - this.radius - this.marginX;
+    const y = height - this.radius - this.marginY;
+
+    this.defaultBase = { x, y };
+    if (this.pointerId === null || this.mode === 'fixed') {
+      this.base.setPosition(x, y);
+      this.thumb.setPosition(x, y);
+    }
+  }
+
+  private onResize(width: number, height: number) {
+    this.positionDefault(width, height);
+    if (this.pointerId === null) {
+      this.resetValue();
+    }
+  }
+
+  private isWithinZone(pointer: Phaser.Input.Pointer) {
+    const halfWidth = this.scene.scale.width / 2;
+    const inHalf =
+      this.side === 'left' ? pointer.x <= halfWidth : pointer.x >= halfWidth;
+
+    if (this.mode === 'floating') {
+      return inHalf;
+    }
+
+    const dx = pointer.x - this.base.x;
+    const dy = pointer.y - this.base.y;
+    const inCircle = dx * dx + dy * dy <= this.radius * this.radius * 1.2;
+    return inHalf || inCircle;
+  }
+
+  private clampToHalf(x: number, y: number): Vector {
+    const width = this.scene.scale.width;
+    const height = this.scene.scale.height;
+    const halfWidth = width / 2;
+
+    const minX = this.radius + this.marginX;
+    const maxX = width - this.radius - this.marginX;
+    const minY = this.radius + this.marginY;
+    const maxY = height - this.radius - this.marginY;
+
+    const clampedX =
+      this.side === 'left'
+        ? Phaser.Math.Clamp(x, minX, halfWidth - this.marginX * 0.5)
+        : Phaser.Math.Clamp(x, halfWidth + this.marginX * 0.5, maxX);
+    const clampedY = Phaser.Math.Clamp(y, minY, maxY);
+
+    return { x: clampedX, y: clampedY };
+  }
+
+  private drawGraphics() {
+    this.base.clear();
+    this.thumb.clear();
+
+    this.base.setDepth(this.depth);
+    this.thumb.setDepth(this.depth + 1);
+
+    this.base.fillStyle(0xffffff, 0.15);
+    this.base.fillCircle(0, 0, this.radius);
+    this.base.lineStyle(3, 0xffffff, 0.35);
+    this.base.strokeCircle(0, 0, this.radius);
+
+    this.thumb.fillStyle(0xffffff, 0.6);
+    this.thumb.fillCircle(0, 0, this.thumbRadius);
+    this.thumb.lineStyle(2, 0x000000, 0.6);
+    this.thumb.strokeCircle(0, 0, this.thumbRadius);
+  }
+}

--- a/src/renderer/src/game/main.ts
+++ b/src/renderer/src/game/main.ts
@@ -20,7 +20,10 @@ const config: Phaser.Types.Core.GameConfig = {
   },
   parent: 'game-container',
   backgroundColor: '#000000',
-  scene: [Boot, Preloader, MainMenu, Game, GameOver, Settings]
+  scene: [Boot, Preloader, MainMenu, Game, GameOver, Settings],
+  input: {
+    activePointers: 3
+  }
 };
 
 const StartGame = (parent: string) => {

--- a/src/renderer/src/game/weapons/MorningStar.ts
+++ b/src/renderer/src/game/weapons/MorningStar.ts
@@ -112,9 +112,12 @@ export class MorningStar extends Weapon {
   attack(): void {
     if (!(this.scene instanceof Game)) return;
 
-    const pointer = this.scene.input.activePointer;
-    const dx = pointer.worldX - this.player.x;
-    const dy = pointer.worldY - this.player.y;
+    const target = this.scene.inputManager.getAimWorldPoint(
+      this.player.x,
+      this.player.y
+    );
+    const dx = target.x - this.player.x;
+    const dy = target.y - this.player.y;
     const len = Math.hypot(dx, dy) || 1;
 
     const impactX = this.player.x + (dx / len) * this.reach;

--- a/src/renderer/src/game/weapons/Needle.ts
+++ b/src/renderer/src/game/weapons/Needle.ts
@@ -54,11 +54,14 @@ export class Needle extends Weapon {
 
   attack(): void {
     if (!this.speed || !this.lifetime) return;
+    const game = this.scene as Game;
+    const target = game.inputManager.getAimWorldPoint(
+      this.player.x,
+      this.player.y
+    );
 
-    const pointer = this.scene.input.activePointer;
-
-    const baseDx = pointer.worldX - this.player.x;
-    const baseDy = pointer.worldY - this.player.y;
+    const baseDx = target.x - this.player.x;
+    const baseDy = target.y - this.player.y;
     const baseAngle = Math.atan2(baseDy, baseDx);
 
     const count = this.level === 5 ? 2 : 1;

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -5,10 +5,19 @@
   font-family: Arial, Helvetica, sans-serif;
 }
 
+html,
 body {
   margin: 0;
   background-color: black;
   color: white;
+  overscroll-behavior: none;
+  height: 100%;
+}
+
+#game-container {
+  width: 100%;
+  height: 100dvh;
+  overflow: hidden;
 }
 
 canvas {
@@ -16,4 +25,5 @@ canvas {
   margin: 0 auto;
   background-color: #111;
   position: fixed;
+  touch-action: none;
 }


### PR DESCRIPTION
## Summary
- harden touch controls with extra pointers, resize-aware joystick layout, and optional floating bases
- add joystick enable/visibility/reset controls to avoid stealing UI taps during pauses or modals
- smooth movement/aim vectors and tighten CSS to reduce jitter and edge gestures on mobile

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b90f720508332bcceafbc2084de50)